### PR TITLE
[Bug Fix] Fix incompatible types in assignment of ‘uint8*’ {aka ‘unsigned char*’} to ‘uint8  in glfw.cpp

### DIFF
--- a/src/skel/glfw/glfw.cpp
+++ b/src/skel/glfw/glfw.cpp
@@ -2500,7 +2500,7 @@ void CapturePad(RwInt32 padID)
 		ControlsManager.m_NewState.mappedButtons[15] = ControlsManager.m_NewState.mappedButtons[16] = 0;
 	}
 
-	ControlsManager.m_NewState.buttons = (uint8*)buttons;
+	memcpy(ControlsManager.m_NewState.buttons, buttons, sizeof(ControlsManager.m_NewState.buttons));
 	ControlsManager.m_NewState.numButtons = numButtons;
 	ControlsManager.m_NewState.id = glfwPad;
 	ControlsManager.m_NewState.isGamepad = glfwGetGamepadState(glfwPad, &gamepadState);


### PR DESCRIPTION

Fixes #15 

Replaces a shallow pointer assignment with a memory copy (memcpy) to fix a potential data aliasing bug and improve memory safety within the ControlsManager state update logic.

**Changes**

- Refactor: Updated the ControlsManager.m_NewState.buttons update logic from direct pointer assignment to memcpy.

- Logic: ControlsManager.m_NewState.buttons = (uint8*)buttons; → memcpy(ControlsManager.m_NewState.buttons, buttons, sizeof(ControlsManager.m_NewState.buttons));.
