### PR TITLE
Fixed Shotgun Reloading Ammo Sound

### DIFF
--- a/src/weapons/WeaponInfo.cpp
+++ b/src/weapons/WeaponInfo.cpp
@@ -30,7 +30,7 @@ uint16 CWeaponInfo::ms_aReloadSampleTime[WEAPONTYPE_TOTALWEAPONS] =
 	0,			// ROCKET
 	250,		// COLT45
 	250,		// PYTHON
-	650,		// SHOTGUN
+	150,		// SHOTGUN
 	650,		// SPAS12 SHOTGUN
 	650,		// STUBBY SHOTGUN
 	400,		// TEC9


### PR DESCRIPTION
It was a bug on reVC (shotgun 150 not 650), with a result, fixed the reloading ammo sound bug.
